### PR TITLE
pyroject.toml: change requires-python to 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,12 @@ license = { file = "LICENSE" }
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.8",
     "Topic :: System :: Hardware",
 ]
 keywords = ["ocp", "ocptv", "pci", "pcie", "lmt"]
 dependencies = []
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
 dev = ["black", "bumpver", "isort", "pylint", "mypy", "build", "twine"]


### PR DESCRIPTION
The README states `Minimum python version is currently py3.8` but pyproject.toml
requires `>= 3.9`.   All tests listed in the `Developer notes` section of the README pass
with python v3.8.10.

I have a python 3.8 environment where I would like to use ocp-diag-pci_lmt thus
the pull request to make this change.