### PR TITLE
Removed the invalid Voltage range checks

### DIFF
--- a/src/pci_lmt/pcie_lane_margining.py
+++ b/src/pci_lmt/pcie_lane_margining.py
@@ -718,14 +718,6 @@ class PcieDeviceLaneMargining:
         if receiver_number not in [*range(0x1, 0x7)]:
             return {"error": f"ERROR: StepMarginVoltageOffsetUpDownOfDefault - BAD receiver_number {receiver_number}"}
 
-        if steps not in [
-            *range(
-                PARAMETERS["NumVoltageSteps"].min,
-                PARAMETERS["NumVoltageSteps"].max + 1,
-            )
-        ]:
-            return {"error": f"ERROR: StepMarginVoltageOffsetUpDownOfDefault - BAD Steps {steps}"}
-
         if up_down in (0, 1):
             margin_payload = up_down << 6 | steps
         else:

--- a/src/pci_lmt/pcie_lane_margining.py
+++ b/src/pci_lmt/pcie_lane_margining.py
@@ -8,7 +8,7 @@ import time
 import typing as ty
 from dataclasses import dataclass
 
-from pci_lmt.constants import MARGIN_RESPONSE, PARAMETERS
+from pci_lmt.constants import MARGIN_RESPONSE
 from pci_lmt.device import PciDevice
 
 logger: logging.Logger = logging.getLogger(__name__)


### PR DESCRIPTION
Minimum voltage steps (in both positive and negative direction) from the default sample location that a device should support is specified by the spec which is 32 -127.

But, the above range was incorrectly compared during Lane Margining which results in failure for step-0 (which is the sample location). Hence, removed the check for now. May need to add this check when reading the device capabilities to confirm that the supported range is as specified by the spec.