### PR TITLE
Added "--force" parameter to force margining on devices that doesn't support independent margin samplers

### DIFF
--- a/src/pci_lmt/args.py
+++ b/src/pci_lmt/args.py
@@ -45,3 +45,9 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
         help="Print tool version and exit.",
         version="%(prog)s " + PCI_LMT_VERSION,
     )
+    parser.add_argument(
+        "--force",
+        dest="force_margin",
+        action="store_true",
+        help="Force margining on devices that doesn't support independent sampling. Default: False",
+    )

--- a/src/pci_lmt/collector.py
+++ b/src/pci_lmt/collector.py
@@ -51,40 +51,37 @@ class PcieLmCollector:
             for lane in range(dev.device_info.width):
                 dev.no_command(lane=lane)
 
-    def info_lane_margin_on_device_list(self):
+    def info_lane_margin_on_device_list(self, args: argparse.Namespace):
         for dev in self.devices:
-            for lane in [0]:
-                ret = dev.fetch_margin_control_capabilities(lane=lane, receiver_number=self.receiver_number)
+            # Collect lane margin capabilties only from lane-0 since it's going to be same
+            # for all lanes on that device.
+            ret = dev.goto_normal_settings(lane=0, receiver_number=self.receiver_number)
+            ret = dev.fetch_margin_control_capabilities(lane=0, receiver_number=self.receiver_number)
 
-                # Run only on devices that support Lane Margining and Independent Error Sampler.
-                # Skip if the device doesn't support independent error sampler.
-                # TODO: This requires special handling since this is INTRUSIVE:
-                # 1. Provide a special flag to force margining on these devices.
-                # 2. Modify the margining sequence to margin one lane at a time (to avoid loosing connectivity)
-                if ret["error"] is None and dev.device_info.ind_error_sampler:
+            status_str = "Device %s ReceiverNum %d " % (dev.device_info.bdf, self.receiver_number)
+            if ret["error"]:
+                dev.primed = False
+                status_str += "NOT PRIMED (%s)" % ret["error"]
+            else:
+                # By default, allow devices only with independent error sampler to be primed.
+                # Allow devices with no independent error sampler to be primed only if it's forced by user.
+                if dev.device_info.ind_error_sampler:
                     dev.primed = True
-                    logger.info(
-                        "Device %s ReceiverNum %d PRIMED: %s",
-                        dev.device_info.bdf,
-                        self.receiver_number,
-                        dev.device_info,
-                    )
-                    continue
+                    status_str += "PRIMED"
+                elif args.force_margin:
+                    dev.primed = True
+                    status_str += "PRIMED (forcing margin on non-independent sampler)"
+                else:
+                    dev.primed = False
+                    status_str += "NOT PRIMED (doesn't support independent error sampler)"
 
-                # If the device is skipped due to the absence independent error sampler,
-                # update the error message to say so.
-                if ret["error"] is None and dev.device_info.ind_error_sampler == 0:
-                    ret["error"] = "Receiver does not support independent error sampler"
-
-                logger.warning(
-                    "Device %s ReceiverNum %d NOT PRIMED: %s",
-                    dev.device_info.bdf,
-                    self.receiver_number,
-                    ret["error"],
-                )
+            if dev.primed:
+                logger.info(status_str)
+            else:
+                logger.warning(status_str)
                 # Mark all lanes faulty.
                 for lane in range(dev.device_info.width):
-                    dev.lane_errors[lane] = ret["error"]
+                    dev.lane_errors[lane] = status_str
 
     def setup_lane_margin_on_device_list(self):
         for dev in self._primed_devices:
@@ -199,19 +196,18 @@ def get_curr_timestamp() -> int:
 
 
 # pylint: disable=too-many-arguments,too-many-locals
+# FIXME: The args param should not be here, arg parsing and usage should be limited to main.py
 def collect_lmt_on_bdfs(
+    args: argparse.Namespace,
     hostname,
     host_id,
     model_name,
     bdf_list,
     receiver_number: int = 0x1,
-    error_count_limit: int = 50,
     left_right_none: int = 0,
     up_down=None,
     steps: int = 13,
     voltage_or_timing: str = "TIMING",
-    dwell_time: int = 5,
-    annotation: str = "",
 ) -> ty.List[LmtLaneResult]:
     # Gather test level info.
     test_info = LmtTestInfo()
@@ -220,31 +216,31 @@ def collect_lmt_on_bdfs(
     test_info.host_id = host_id
     test_info.hostname = hostname
     test_info.model_name = model_name
-    test_info.dwell_time_secs = dwell_time
-    test_info.error_count_limit = error_count_limit
+    test_info.dwell_time_secs = args.dwell_time
+    test_info.error_count_limit = args.error_count_limit
     test_info.test_version = PCI_LMT_VERSION
-    test_info.annotation = annotation
+    test_info.annotation = args.annotation
 
     logger.info("%s", test_info)
     devices = PcieLmCollector(bdf_list)
 
     devices.sampler_setup(
         receiver_number=receiver_number,
-        error_count_limit=error_count_limit,
+        error_count_limit=args.error_count_limit,
         left_right_none=left_right_none,
         up_down=up_down,
         steps=steps,
         voltage_or_timing=voltage_or_timing,
     )
     devices.no_command_on_device_list()
-    devices.info_lane_margin_on_device_list()
+    devices.info_lane_margin_on_device_list(args)
     devices.no_command_on_device_list()
     devices.clear_error_log_on_device_list()
     devices.normal_settings_on_device_list()
     devices.setup_lane_margin_on_device_list()
 
     start_time = time.time()
-    time.sleep(dwell_time)
+    time.sleep(args.dwell_time)
     results = devices.collect_lane_margin_on_device_list(
         voltage_or_timing=devices.voltage_or_timing,
         steps=devices.steps,
@@ -270,7 +266,7 @@ def run_lmt(args: argparse.Namespace, config: PlatformConfig, host: HostInfo, re
     logger.info("Loading config: %s", config)
 
     for group in config.lmt_groups:
-        annotation = args.annotation if args.annotation else group.name
+        args.annotation = args.annotation if args.annotation else group.name
         left_right_none, up_down = group.margin_directions_tuple
         # Loop through each step running LMT on all BDFs.
         for step in group.margin_steps:
@@ -286,18 +282,16 @@ def run_lmt(args: argparse.Namespace, config: PlatformConfig, host: HostInfo, re
                 args.dwell_time,
             )
             results = collect_lmt_on_bdfs(
+                args=args,
                 hostname=host.hostname,
                 host_id=host.host_id,
                 model_name=host.model_name,
                 bdf_list=bdf_list,
                 receiver_number=receiver_number,
-                error_count_limit=args.error_count_limit,
                 left_right_none=left_right_none,
                 up_down=up_down,
                 steps=step,
                 voltage_or_timing=margin_type,
-                dwell_time=args.dwell_time,
-                annotation=annotation,
             )
             for result in results:
                 logger.info(result)

--- a/src/pci_lmt/pcie_lane_margining.py
+++ b/src/pci_lmt/pcie_lane_margining.py
@@ -8,7 +8,7 @@ import time
 import typing as ty
 from dataclasses import dataclass
 
-from pci_lmt.constants import MARGIN_RESPONSE, PARAMETERS
+from pci_lmt.constants import MARGIN_RESPONSE
 from pci_lmt.device import PciDevice
 
 logger: logging.Logger = logging.getLogger(__name__)


### PR DESCRIPTION
By default, the devices with no independent samplers will be skipped since it's an intrusive tests. This is required to avoid margining on devices that doesn't support independent samplers accidentally.

Verified on a NIC which doesn't have independent sampler:

```
# Default args
[root@dut /tmp]# ./pci_lmt.par auto -c lmt.cfg.nics -o json -v
:
WARNING: Device 0000:2d:00.0 ReceiverNum 6 NOT PRIMED (doesn't support independent error sampler)
WARNING: Device 0000:cd:00.0 ReceiverNum 6 NOT PRIMED (doesn't support independent error sampler)
: 
{"test_info": {"run_id": "18821378487075395062806078677367738132", "timestamp": 1712523512, "host_id": "323367020", "hostname": "redacted", "model_name": "redacted", "dwell_time_secs": 5, "elapsed_time_secs": 5.0051515102386475, "error_count_limit": 63, "test_version": "1.2.1", "annotation": "CPU Tx -> NIC Rx (Timing right)"}, "device_info": {"bdf": "0000:2d:00.0", "speed": "32GT/s", "width": 16, "lmt_capable": true, "ind_error_sampler": 0, "sample_reporting_method": 1, "ind_left_right_timing": 1, "ind_up_down_voltage": 1, "voltage_supported": 1, "num_voltage_steps": 32, "num_timing_steps": 15, "max_timing_offset": 0, "max_voltage_offset": 0, "sampling_rate_voltage": 31, "sampling_rate_timing": 31, "max_lanes": 15, "reserved": 0}, "lane": 0, "receiver_number": 6, "margin_type": "timing_right", "step": 10, "sample_count": -1, "sample_count_bits": -1, "error_count": -1, "ber": -1.0, "error": true, "error_msg": "Device 0000:2d:00.0 ReceiverNum 6 NOT PRIMED (doesn't support independent error sampler)"}

# With force option
[root@dut /tmp]# ./pci_lmt.par auto -c lmt.cfg.nics -o json -v --force                                                                                                                                                                
: 
INFO: Device 0000:2d:00.0 ReceiverNum 6 PRIMED (forcing margin on non-independent sampler)
INFO: Device 0000:cd:00.0 ReceiverNum 6 PRIMED (forcing margin on non-independent sampler)
: 
{"test_info": {"run_id": "1559880706044973918415362741723491024796", "timestamp": 1712523603, "host_id": "323367020", "hostname": "redacted", "model_name": "redacted", "dwell_time_secs": 5, "elapsed_time_secs": 5.380047559738159, "error_count_limit": 63, "test_version": "1.2.1", "annotation": "CPU Tx -> NIC Rx (Timing right)"}, "device_info": {"bdf": "0000:2d:00.0", "speed": "32GT/s", "width": 16, "lmt_capable": true, "ind_error_sampler": 0, "sample_reporting_method": 1, "ind_left_right_timing": 1, "ind_up_down_voltage": 1, "voltage_supported": 1, "num_voltage_steps": 32, "num_timing_steps": 15, "max_timing_offset": 0, "max_voltage_offset": 0, "sampling_rate_voltage": 31, "sampling_rate_timing": 31, "max_lanes": 15, "reserved": 0}, "lane": 0, "receiver_number": 6, "margin_type": "timing_right", "step": 10, "sample_count": 0, "sample_count_bits": 1, "error_count": 0, "ber": 0.0, "error": false, "error_msg": ""}
```

