### PR TITLE
Added initial support for OCP-TV output format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pylint>=2.17.5
 mypy>=1.5.1
 TestSlide>=2.7.1
 bumpver>=2023.1126
+ocptv>=0.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pylint>=2.17.5
 mypy>=1.5.1
 TestSlide>=2.7.1
 bumpver>=2023.1126
-ocptv>=0.1.6
+ocptv>=0.1.7

--- a/src/pci_lmt/collector.py
+++ b/src/pci_lmt/collector.py
@@ -265,41 +265,36 @@ def run_lmt(args: argparse.Namespace, config: PlatformConfig, host: HostInfo, re
     """Runs LMT tests on all the interfaces listed in the platform_config."""
 
     logger.info("Loading config: %s", config)
-    reporter.start_run(host, PCI_LMT_VERSION)
-
-    for group in config.lmt_groups:
-        args.annotation = args.annotation if args.annotation else group.name
-        left_right_none, up_down = group.margin_directions_tuple
-        # Loop through each step running LMT on all BDFs.
-        for step in group.margin_steps:
-            reporter.start_step(name=f"Rcvr:{group.receiver_number} Step:{step} Ann:{args.annotation}")
-            bdf_list = group.bdf_list
-            margin_type = group.margin_type
-            receiver_number = group.receiver_number
-            logger.info(
-                "Running %s margining test on %d BDFs Rx %d Step %d for %d seconds.",
-                margin_type,
-                len(bdf_list),
-                receiver_number,
-                step,
-                args.dwell_time,
-            )
-            results = collect_lmt_on_bdfs(
-                args=args,
-                hostname=host.hostname,
-                host_id=host.host_id,
-                model_name=host.model_name,
-                bdf_list=bdf_list,
-                receiver_number=receiver_number,
-                left_right_none=left_right_none,
-                up_down=up_down,
-                steps=step,
-                voltage_or_timing=margin_type,
-            )
-            for result in results:
-                logger.info(result)
-                reporter.write(result)
-
-            reporter.end_step()
-
-    reporter.end_run()
+    with reporter.start_run(host):
+        for group in config.lmt_groups:
+            args.annotation = args.annotation if args.annotation else group.name
+            left_right_none, up_down = group.margin_directions_tuple
+            # Loop through each step running LMT on all BDFs.
+            for step in group.margin_steps:
+                with reporter.start_step(name=f"Rcvr:{group.receiver_number} Step:{step} Ann:{args.annotation}"):
+                    bdf_list = group.bdf_list
+                    margin_type = group.margin_type
+                    receiver_number = group.receiver_number
+                    logger.info(
+                        "Running %s margining test on %d BDFs Rx %d Step %d for %d seconds.",
+                        margin_type,
+                        len(bdf_list),
+                        receiver_number,
+                        step,
+                        args.dwell_time,
+                    )
+                    results = collect_lmt_on_bdfs(
+                        args=args,
+                        hostname=host.hostname,
+                        host_id=host.host_id,
+                        model_name=host.model_name,
+                        bdf_list=bdf_list,
+                        receiver_number=receiver_number,
+                        left_right_none=left_right_none,
+                        up_down=up_down,
+                        steps=step,
+                        voltage_or_timing=margin_type,
+                    )
+                    for result in results:
+                        logger.info(result)
+                        reporter.write(result)

--- a/src/pci_lmt/collector.py
+++ b/src/pci_lmt/collector.py
@@ -264,12 +264,14 @@ def run_lmt(args: argparse.Namespace, config: PlatformConfig, host: HostInfo, re
     """Runs LMT tests on all the interfaces listed in the platform_config."""
 
     logger.info("Loading config: %s", config)
+    reporter.start_run(host, PCI_LMT_VERSION)
 
     for group in config.lmt_groups:
         args.annotation = args.annotation if args.annotation else group.name
         left_right_none, up_down = group.margin_directions_tuple
         # Loop through each step running LMT on all BDFs.
         for step in group.margin_steps:
+            reporter.start_step(name=f"Rcvr:{group.receiver_number} Step:{step} Ann:{args.annotation}")
             bdf_list = group.bdf_list
             margin_type = group.margin_type
             receiver_number = group.receiver_number
@@ -296,3 +298,7 @@ def run_lmt(args: argparse.Namespace, config: PlatformConfig, host: HostInfo, re
             for result in results:
                 logger.info(result)
                 reporter.write(result)
+
+            reporter.end_step()
+
+    reporter.end_run()

--- a/src/pci_lmt/collector.py
+++ b/src/pci_lmt/collector.py
@@ -109,6 +109,7 @@ class PcieLmCollector:
                     receiver_number=ty.cast(int, self.receiver_number),
                     step=steps,
                 )
+                stepper = {}
                 if voltage_or_timing == "TIMING":
                     # FIXME: move this string construction in a separate method; or better make it
                     # into a typed enum

--- a/src/pci_lmt/results.py
+++ b/src/pci_lmt/results.py
@@ -7,6 +7,9 @@ import dataclasses as dc
 import json
 import typing as ty
 
+import ocptv.output as tv
+from ocptv.output import TestResult, TestStatus
+from pci_lmt.host import HostInfo
 from pci_lmt.pcie_lane_margining import LmtDeviceInfo
 
 
@@ -64,6 +67,21 @@ class LmtLaneResult:  # pylint: disable=too-many-instance-attributes,too-few-pub
 
 
 class Reporter:
+    def __init__(self):
+        pass
+
+    def start_run(self, host: HostInfo, version:str) -> None:
+        pass
+
+    def end_run(self) -> None:
+        pass
+
+    def start_step(self, name: str) -> None:
+        pass
+
+    def end_step(self) -> None:
+        pass
+
     def write(self, _result: LmtLaneResult) -> None:
         pass
 
@@ -84,3 +102,31 @@ class CsvStdoutReporter(Reporter):
             self.__emitted_header = True
 
         print(row)
+
+class OctTvOutputReporter(Reporter):
+    def __init__(self):
+        # TODO(sksekar): Add support for saving to file.
+        pass
+
+    def start_run(self, host: HostInfo, version:str) -> None:
+        # TODO(sksekar): Add support for HardwareInfo using PlatformConfig.
+        self._run = tv.TestRun(name="pci_lmt", version=version)
+        dut = tv.Dut(id=host.host_id, name=host.hostname)
+        self._run.start(dut=dut)
+
+    def end_run(self) -> None:
+        # TODO(sksekar): Add support for checking actual result based on error count.
+        self._run.end(status=TestStatus.COMPLETE, result=TestResult.PASS)
+
+    def start_step(self, name: str) -> None:
+        # TODO(sksekar): Add support for validators.
+        self._step = self._run.add_step(name=name)
+        self._step.start()
+
+    def end_step(self) -> None:
+        # TODO(sksekar): Add support for deducing results using validators.
+        self._step.end(status=TestStatus.COMPLETE)
+
+    def write(self, result: LmtLaneResult) -> None:
+        meas_name = f"BDF:{result.device_info.bdf} Lane:{result.lane}"
+        self._step.add_measurement(name=meas_name, value=result.ber)

--- a/src/pci_lmt/results.py
+++ b/src/pci_lmt/results.py
@@ -70,7 +70,7 @@ class Reporter:
     def __init__(self):
         pass
 
-    def start_run(self, host: HostInfo, version:str) -> None:
+    def start_run(self, host: HostInfo, version: str) -> None:
         pass
 
     def end_run(self) -> None:
@@ -103,12 +103,14 @@ class CsvStdoutReporter(Reporter):
 
         print(row)
 
+
 class OctTvOutputReporter(Reporter):
     def __init__(self):
         # TODO(sksekar): Add support for saving to file.
-        pass
+        self._run: tv.TestRun = None
+        self._step: tv.TestStep = None
 
-    def start_run(self, host: HostInfo, version:str) -> None:
+    def start_run(self, host: HostInfo, version: str) -> None:
         # TODO(sksekar): Add support for HardwareInfo using PlatformConfig.
         self._run = tv.TestRun(name="pci_lmt", version=version)
         dut = tv.Dut(id=host.host_id, name=host.hostname)

--- a/src/pci_lmt_bin/main.py
+++ b/src/pci_lmt_bin/main.py
@@ -20,7 +20,7 @@ from pci_lmt.host import HostInfo
 from pci_lmt.results import (
     CsvStdoutReporter,
     JsonStdoutReporter,
-    OctTvOutputReporter,
+    OcptvReporter,
     Reporter,
 )
 
@@ -64,7 +64,7 @@ def main() -> None:
     elif args.output == "csv":
         reporter = CsvStdoutReporter()
     elif args.output == "ocp":
-        reporter = OctTvOutputReporter()
+        reporter = OcptvReporter()
 
     collector.run_lmt(
         args=args,

--- a/src/pci_lmt_bin/main.py
+++ b/src/pci_lmt_bin/main.py
@@ -17,7 +17,12 @@ from pci_lmt import collector
 from pci_lmt.args import add_common_args
 from pci_lmt.config import read_platform_config
 from pci_lmt.host import HostInfo
-from pci_lmt.results import CsvStdoutReporter, JsonStdoutReporter, Reporter
+from pci_lmt.results import (
+    CsvStdoutReporter,
+    JsonStdoutReporter,
+    OctTvOutputReporter,
+    Reporter,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -33,9 +38,9 @@ def parse_args() -> argparse.Namespace:
         "-o",
         dest="output",
         type=str,
-        help="Output format. Supported formats: json, csv. Default: json",
+        help="Output format. Supported formats: json, csv, ocp. Default: json",
         default="json",
-        choices=["json", "csv"],
+        choices=["json", "csv", "ocp"],
     )
     add_common_args(parser)
 
@@ -58,6 +63,8 @@ def main() -> None:
         reporter = JsonStdoutReporter()
     elif args.output == "csv":
         reporter = CsvStdoutReporter()
+    elif args.output == "ocp":
+        reporter = OctTvOutputReporter()
 
     collector.run_lmt(
         args=args,


### PR DESCRIPTION
This is to add initial support. Yet to add support for validators, pass/fail etc.

Sample OCP-TV output:

```
    {"schemaVersion": {"major": 2, "minor": 0}, "sequenceNumber": 0, "timestamp": "2024-08-19T00:30:31.094657Z"}
    {"testRunArtifact": {"testRunStart": {"name": "pci_lmt", "version": "1.3.1", "commandLine": "-o ocp -c lmt.cfg auto", "parameters": {}, "dutInfo": {"dutInfoId": "319706019", "name": "hostname", "platformInfos": [], "softwareInfos": [], "hardwareInfos": []}}}, "sequenceNumber": 1, "timestamp": "2024-08-19T00:30:31.094946Z"}
    {"testStepArtifact": {"testStepId": "0", "testStepStart": {"name": "Rcvr:6 Step:5 Ann:CPU Tx -> Retimer Rx (Timing left)"}}, "sequenceNumber": 2, "timestamp": "2024-08-19T00:30:31.095273Z"}
    {"testStepArtifact": {"testStepId": "0", "measurement": {"name": "BDF:0000:1a:00.0 Lane:0", "value": 0.0, "validators": []}}, "sequenceNumber": 3, "timestamp": "2024-08-19T00:30:36.691321Z"}
    {"testStepArtifact": {"testStepId": "0", "measurement": {"name": "BDF:0000:1a:00.0 Lane:1", "value": 0.0, "validators": []}}, "sequenceNumber": 4, "timestamp": "2024-08-19T00:30:36.691972Z"}
    {"testStepArtifact": {"testStepId": "0", "measurement": {"name": "BDF:0000:1a:00.0 Lane:2", "value": 0.0, "validators": []}}, "sequenceNumber": 5, "timestamp": "2024-08-19T00:30:36.692493Z"}
    {"testStepArtifact": {"testStepId": "0", "measurement": {"name": "BDF:0000:1a:00.0 Lane:3", "value": 0.0, "validators": []}}, "sequenceNumber": 6, "timestamp": "2024-08-19T00:30:36.692845Z"}
    {"testStepArtifact": {"testStepId": "0", "measurement": {"name": "BDF:0000:1a:00.0 Lane:4", "value": 0.0, "validators": []}}, "sequenceNumber": 7, "timestamp": "2024-08-19T00:30:36.693209Z"}
    {"testStepArtifact": {"testStepId": "0", "measurement": {"name": "BDF:0000:1a:00.0 Lane:5", "value": 0.0, "validators": []}}, "sequenceNumber": 8, "timestamp": "2024-08-19T00:30:36.693568Z"}
    {"testStepArtifact": {"testStepId": "0", "measurement": {"name": "BDF:0000:1a:00.0 Lane:6", "value": 0.0, "validators": []}}, "sequenceNumber": 9, "timestamp": "2024-08-19T00:30:36.693947Z"}
    {"testStepArtifact": {"testStepId": "0", "measurement": {"name": "BDF:0000:1a:00.0 Lane:7", "value": 0.0, "validators": []}}, "sequenceNumber": 10, "timestamp": "2024-08-19T00:30:36.694338Z"}
    {"testStepArtifact": {"testStepId": "0", "testStepEnd": {"status": "COMPLETE"}}, "sequenceNumber": 11, "timestamp": "2024-08-19T00:30:36.694586Z"}
    {"testStepArtifact": {"testStepId": "1", "testStepStart": {"name": "Rcvr:6 Step:6 Ann:CPU Tx -> Retimer Rx (Timing left)"}}, "sequenceNumber": 12, "timestamp": "2024-08-19T00:30:36.694755Z"}
    {"testStepArtifact": {"testStepId": "1", "measurement": {"name": "BDF:0000:1a:00.0 Lane:0", "value": 0.0, "validators": []}}, "sequenceNumber": 13, "timestamp": "2024-08-19T00:30:42.283159Z"}
    {"testStepArtifact": {"testStepId": "1", "measurement": {"name": "BDF:0000:1a:00.0 Lane:1", "value": 0.0, "validators": []}}, "sequenceNumber": 14, "timestamp": "2024-08-19T00:30:42.283600Z"}
    {"testStepArtifact": {"testStepId": "1", "measurement": {"name": "BDF:0000:1a:00.0 Lane:2", "value": 0.0, "validators": []}}, "sequenceNumber": 15, "timestamp": "2024-08-19T00:30:42.283974Z"}
    {"testStepArtifact": {"testStepId": "1", "measurement": {"name": "BDF:0000:1a:00.0 Lane:3", "value": 0.0, "validators": []}}, "sequenceNumber": 16, "timestamp": "2024-08-19T00:30:42.284312Z"}
    {"testStepArtifact": {"testStepId": "1", "measurement": {"name": "BDF:0000:1a:00.0 Lane:4", "value": 0.0, "validators": []}}, "sequenceNumber": 17, "timestamp": "2024-08-19T00:30:42.284669Z"}
    {"testStepArtifact": {"testStepId": "1", "measurement": {"name": "BDF:0000:1a:00.0 Lane:5", "value": 0.0, "validators": []}}, "sequenceNumber": 18, "timestamp": "2024-08-19T00:30:42.285002Z"}
    {"testStepArtifact": {"testStepId": "1", "measurement": {"name": "BDF:0000:1a:00.0 Lane:6", "value": 0.0, "validators": []}}, "sequenceNumber": 19, "timestamp": "2024-08-19T00:30:42.285358Z"}
    {"testStepArtifact": {"testStepId": "1", "measurement": {"name": "BDF:0000:1a:00.0 Lane:7", "value": 0.0, "validators": []}}, "sequenceNumber": 20, "timestamp": "2024-08-19T00:30:42.287100Z"}
    {"testStepArtifact": {"testStepId": "1", "testStepEnd": {"status": "COMPLETE"}}, "sequenceNumber": 21, "timestamp": "2024-08-19T00:30:42.287347Z"}
    {"testRunArtifact": {"testRunEnd": {"status": "COMPLETE", "result": "PASS"}}, "sequenceNumber": 22, "timestamp": "2024-08-19T00:30:42.287470Z"}
```