### PR TITLE
Support margin time 

### DIFF
--- a/src/pci_lmt/args.py
+++ b/src/pci_lmt/args.py
@@ -26,6 +26,13 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
         default=5,
     )
     parser.add_argument(
+        "-m",
+        dest="margin_time",
+        type=int,
+        help="Amount of time (in seconds) to stay during margin. Default: 1",
+        default=1,
+    )
+    parser.add_argument(
         "-a",
         dest="annotation",
         type=str,

--- a/src/pci_lmt/collector.py
+++ b/src/pci_lmt/collector.py
@@ -95,7 +95,7 @@ class PcieLmCollector:
     # FIXME: `voltage_or_timing` should be an enum; dont use strings for magic constants
     # pylint: disable=too-many-branches
     def collect_lane_margin_on_device_list(
-        self, voltage_or_timing="TIMING", steps=16, up_down=0, left_right_none=0
+        self, voltage_or_timing="TIMING", steps=16, up_down=0, left_right_none=0, margin_time=1
     ) -> ty.List[LmtLaneResult]:
         """Returns the Lane Margining Test result from all lanes as a list."""
         results = []
@@ -141,6 +141,8 @@ class PcieLmCollector:
                         up_down=up_down,
                         steps=steps,
                     )
+
+                time.sleep(margin_time)
 
                 sampler = dev.fetch_sample_count(lane=lane, receiver_number=self.receiver_number)
                 if stepper["error"] or sampler["error"]:
@@ -218,6 +220,7 @@ def collect_lmt_on_bdfs(
     test_info.hostname = hostname
     test_info.model_name = model_name
     test_info.dwell_time_secs = args.dwell_time
+    test_info.margin_time_secs = args.margin_time
     test_info.error_count_limit = args.error_count_limit
     test_info.test_version = PCI_LMT_VERSION
     test_info.annotation = args.annotation
@@ -247,6 +250,7 @@ def collect_lmt_on_bdfs(
         steps=devices.steps,
         up_down=devices.up_down,
         left_right_none=devices.left_right_none,
+        margin_time=args.margin_time,
     )
     stop_time = time.time()
     test_info.elapsed_time_secs = stop_time - start_time

--- a/src/pci_lmt/pcie_lane_margining.py
+++ b/src/pci_lmt/pcie_lane_margining.py
@@ -675,7 +675,7 @@ class PcieDeviceLaneMargining:
         # Margin Payload[5:0] = MErrorCount
         ret = self.decode_margining_lane_status_register(lane=lane)
         start_time = time.time()
-        while ret["margin_type_status"] != 0x3:
+        while ret["margin_type_status"] != 0x3 or ((ret["margin_payload_status"] & 0xC0) >> 6) != 0x2:
             ret = self.decode_margining_lane_status_register(lane=lane)
             if time.time() - start_time > TIMEOUT:
                 return {"error": "ERROR: decode_StepMarginTimingOffsetRightLeftOfDefault - timedout"}
@@ -759,7 +759,7 @@ class PcieDeviceLaneMargining:
         # Margin Payload[5:0] = MErrorCount
         ret = self.decode_margining_lane_status_register(lane=lane)
         start_time = time.time()
-        while ret["margin_type_status"] != 0x4:
+        while ret["margin_type_status"] != 0x4 or ((ret["margin_payload_status"] & 0xC0) >> 6) != 0x2:
             ret = self.decode_margining_lane_status_register(lane=lane)
             if time.time() - start_time > TIMEOUT:
                 return {"error": "ERROR: decode_StepMarginVoltageOffsetUpDownOfDefault - timedout"}

--- a/src/pci_lmt/results.py
+++ b/src/pci_lmt/results.py
@@ -25,6 +25,7 @@ class LmtTestInfo:  # pylint: disable=too-many-instance-attributes,too-few-publi
     hostname: str = ""
     model_name: str = ""
     dwell_time_secs: int = -1
+    margin_time_secs: int = -1
     elapsed_time_secs: float = -1
     error_count_limit: int = -1
     test_version: str = ""


### PR DESCRIPTION
The following features are enhanced :

* margin time support

Per pcie spec 4.2.18.4
"Software should allow margining to run for at least 10^8 bits margined by the Receiver under test before
switching to the next margin step location (unless the error limit is exceeded)."
The current LMT code does not consider this and once started, the margin is finished without any waiting time.
A new -m _margin_time_ option is added to allow the lane to stay in margin for at least _margin_time_ seconds.

* Fix incorrect margin result
When a margin command is sent to the device, it is possible the device will need some time to prepare the margin, in other words, we need to check the step_margin_execution_status is 0x2  ( margin in progress ) before concluding the margin is in effect.


We run the original code on our products and find the margin results are inconsistent：
 * As the step increases, the margin result experience pass, fail ,pass scenario
 * we find the sample_count_bits is way small than expected ( for example 512 bits ) when error_count is 0
 
After the two fixes, the margin result is consistent.