### PR TITLE
Fixed the bug with the annotation and few fixme's

### DIFF
--- a/src/pci_lmt/collector.py
+++ b/src/pci_lmt/collector.py
@@ -20,13 +20,18 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 
 class PcieLmCollector:
-    def __init__(self, bdf_list: ty.List[str]):
-        self.receiver_number = None
-        self.error_count_limit = None
-        self.left_right_none = None
-        self.up_down = None
-        self.steps = None
-        self.voltage_or_timing = None
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, test_info: LmtTestInfo, bdf_list: ty.List[str]):
+        # TODO: Can use the test_info directly instead of instantiating
+        # individual members. But, this change may litter the code. So,
+        # will handle this in a separate PR.
+        self.receiver_number = test_info.receiver_number
+        self.error_count_limit = test_info.error_count_limit
+        self.left_right_none = test_info.left_right_none
+        self.up_down = test_info.up_down
+        self.step = test_info.step
+        self.margin_type = test_info.margin_type
+        self.force_margin = test_info.force_margin
         self.devices = [PcieDeviceLaneMargining(PciDevice(bdf)) for bdf in bdf_list]
 
     @property
@@ -51,7 +56,7 @@ class PcieLmCollector:
             for lane in range(dev.device_info.width):
                 dev.no_command(lane=lane)
 
-    def info_lane_margin_on_device_list(self, args: argparse.Namespace):
+    def info_lane_margin_on_device_list(self):
         for dev in self.devices:
             # Collect lane margin capabilties only from lane-0 since it's going to be same
             # for all lanes on that device.
@@ -68,7 +73,7 @@ class PcieLmCollector:
                 if dev.device_info.ind_error_sampler:
                     dev.primed = True
                     status_str += "PRIMED"
-                elif args.force_margin:
+                elif self.force_margin:
                     dev.primed = True
                     status_str += "PRIMED (forcing margin on non-independent sampler)"
                 else:
@@ -83,7 +88,7 @@ class PcieLmCollector:
                 for lane in range(dev.device_info.width):
                     dev.lane_errors[lane] = status_str
 
-    def setup_lane_margin_on_device_list(self, voltage_or_timing="TIMING", steps=16, up_down=0, left_right_none=0):
+    def setup_lane_margin_on_device_list(self):
         for dev in self._primed_devices:
             for lane in range(dev.device_info.width):
                 dev.set_error_count_limit(
@@ -92,27 +97,39 @@ class PcieLmCollector:
                     error_count_limit=self.error_count_limit,
                 )
 
-                if voltage_or_timing == "TIMING":
+                if self.margin_type == "TIMING":
                     dev.step_margin_timing_offset_right_left_of_default(
                         lane=lane,
                         receiver_number=self.receiver_number,
-                        left_right_none=left_right_none,
-                        steps=steps,
+                        left_right_none=self.left_right_none,
+                        steps=self.step,
                     )
                 else:
                     dev.step_margin_voltage_offset_up_down_of_default(
                         lane=lane,
                         receiver_number=self.receiver_number,
-                        up_down=up_down,
-                        steps=steps,
+                        up_down=self.up_down,
+                        steps=self.step,
                     )
 
-    # FIXME: `voltage_or_timing` should be an enum; dont use strings for magic constants
-    # pylint: disable=too-many-branches
-    def collect_lane_margin_on_device_list(
-        self, voltage_or_timing="TIMING", steps=16, up_down=0, left_right_none=0
-    ) -> ty.List[LmtLaneResult]:
+    # FIXME: `margin_type` should be an enum; dont use strings for magic constants
+    def collect_lane_margin_on_device_list(self) -> ty.List[LmtLaneResult]:
         """Returns the Lane Margining Test result from all lanes as a list."""
+
+        def get_timing_margin_type_as_str() -> str:
+            if self.left_right_none == 0:
+                return "timing_right"
+            if self.left_right_none == 1:
+                return "timing_left"
+            return "timing_none"
+
+        def get_voltage_margin_type_as_str() -> str:
+            if self.up_down == 0:
+                return "voltage_up"
+            if self.up_down == 1:
+                return "voltage_down"
+            return "voltage_none"
+
         results = []
         for dev in self.devices:
             # Collect results from all devices and lanes
@@ -122,28 +139,14 @@ class PcieLmCollector:
                     device_info=dev.device_info,
                     lane=lane,
                     receiver_number=ty.cast(int, self.receiver_number),
-                    step=steps,
+                    step=self.step,
                 )
 
-                if voltage_or_timing == "TIMING":
-                    # FIXME: move this string construction in a separate method; or better make it
-                    # into a typed enum
-                    lane_result.margin_type = "timing_"
-                    if left_right_none == 0:
-                        lane_result.margin_type += "right"
-                    elif left_right_none == 1:
-                        lane_result.margin_type += "left"
-                    else:
-                        lane_result.margin_type += "none"
+                if self.margin_type == "TIMING":
+                    lane_result.margin_type = get_timing_margin_type_as_str()
                     margin_status = dev.decode_step_margin_timing_offset_right_left_of_default(lane=lane)
                 else:
-                    lane_result.margin_type = "voltage_"
-                    if up_down == 0:
-                        lane_result.margin_type += "up"
-                    elif up_down == 1:
-                        lane_result.margin_type += "down"
-                    else:
-                        lane_result.margin_type += "none"
+                    lane_result.margin_type = get_voltage_margin_type_as_str()
                     margin_status = dev.decode_step_margin_voltage_offset_up_down_of_default(lane=lane)
 
                 sampler = dev.fetch_sample_count(lane=lane, receiver_number=self.receiver_number)
@@ -162,27 +165,6 @@ class PcieLmCollector:
 
         return results
 
-    # MSampleCount Value = 3*log2 (number of bits margined). The count saturates at 127
-    # (after approximately 5.54 × 1012 bits).
-
-    # FIXME: why isnt this part of __init__?
-    # pylint: disable=too-many-arguments
-    def sampler_setup(
-        self,
-        receiver_number=0x1,
-        error_count_limit=50,
-        left_right_none=0,
-        up_down=0,
-        steps=16,
-        voltage_or_timing="TIMING",
-    ):
-        self.receiver_number = receiver_number
-        self.error_count_limit = error_count_limit
-        self.left_right_none = left_right_none
-        self.up_down = up_down
-        self.steps = steps
-        self.voltage_or_timing = voltage_or_timing
-
 
 def get_run_id() -> str:
     """Returns an unique ID using RNG."""
@@ -194,63 +176,20 @@ def get_curr_timestamp() -> int:
     return int(os.popen("date +%s").read().split("\n")[0])
 
 
-# pylint: disable=too-many-arguments,too-many-locals
-# FIXME: The args param should not be here, arg parsing and usage should be limited to main.py
-def collect_lmt_on_bdfs(
-    args: argparse.Namespace,
-    hostname,
-    host_id,
-    model_name,
-    bdf_list,
-    receiver_number: int = 0x1,
-    left_right_none: int = 0,
-    up_down=None,
-    steps: int = 13,
-    voltage_or_timing: str = "TIMING",
-) -> ty.List[LmtLaneResult]:
-    # Gather test level info.
-    test_info = LmtTestInfo()
-    test_info.run_id = get_run_id()
-    test_info.timestamp = get_curr_timestamp()
-    test_info.host_id = host_id
-    test_info.hostname = hostname
-    test_info.model_name = model_name
-    test_info.dwell_time_secs = args.dwell_time
-    test_info.error_count_limit = args.error_count_limit
-    test_info.test_version = PCI_LMT_VERSION
-    test_info.annotation = args.annotation
-
+def collect_lmt_on_bdfs(test_info: LmtTestInfo, bdf_list: ty.List[str]) -> ty.List[LmtLaneResult]:
     logger.info("%s", test_info)
-    devices = PcieLmCollector(bdf_list)
+    devices = PcieLmCollector(test_info, bdf_list)
 
-    devices.sampler_setup(
-        receiver_number=receiver_number,
-        error_count_limit=args.error_count_limit,
-        left_right_none=left_right_none,
-        up_down=up_down,
-        steps=steps,
-        voltage_or_timing=voltage_or_timing,
-    )
     devices.no_command_on_device_list()
-    devices.info_lane_margin_on_device_list(args)
+    devices.info_lane_margin_on_device_list()
     devices.no_command_on_device_list()
     devices.clear_error_log_on_device_list()
     devices.normal_settings_on_device_list()
-    devices.setup_lane_margin_on_device_list(
-        voltage_or_timing=devices.voltage_or_timing,
-        steps=devices.steps,
-        up_down=devices.up_down,
-        left_right_none=devices.left_right_none,
-    )
+    devices.setup_lane_margin_on_device_list()
 
     start_time = time.time()
-    time.sleep(args.dwell_time)
-    results = devices.collect_lane_margin_on_device_list(
-        voltage_or_timing=devices.voltage_or_timing,
-        steps=devices.steps,
-        up_down=devices.up_down,
-        left_right_none=devices.left_right_none,
-    )
+    time.sleep(test_info.dwell_time_secs)
+    results = devices.collect_lane_margin_on_device_list()
     stop_time = time.time()
     test_info.elapsed_time_secs = stop_time - start_time
 
@@ -269,35 +208,30 @@ def run_lmt(args: argparse.Namespace, config: PlatformConfig, host: HostInfo, re
 
     logger.info("Loading config: %s", config)
     with reporter.start_run(host):
+        test_info = LmtTestInfo()
+        test_info.run_id = get_run_id()
+        test_info.timestamp = get_curr_timestamp()
+        test_info.host_id = host.host_id
+        test_info.hostname = host.hostname
+        test_info.model_name = host.model_name
+        test_info.dwell_time_secs = args.dwell_time
+        test_info.error_count_limit = args.error_count_limit
+        test_info.force_margin = args.force_margin
+        test_info.test_version = PCI_LMT_VERSION
+
         for group in config.lmt_groups:
-            args.annotation = args.annotation if args.annotation else group.name
-            left_right_none, up_down = group.margin_directions_tuple
+            test_info.margin_type = group.margin_type
+            test_info.receiver_number = group.receiver_number
+            test_info.annotation = args.annotation if args.annotation else group.name
+            test_info.left_right_none, test_info.up_down = group.margin_directions_tuple
+
             # Loop through each step running LMT on all BDFs.
             for step in group.margin_steps:
-                with reporter.start_step(name=f"Rcvr:{group.receiver_number} Step:{step} Ann:{args.annotation}"):
-                    bdf_list = group.bdf_list
-                    margin_type = group.margin_type
-                    receiver_number = group.receiver_number
-                    logger.info(
-                        "Running %s margining test on %d BDFs Rx %d Step %d for %d seconds.",
-                        margin_type,
-                        len(bdf_list),
-                        receiver_number,
-                        step,
-                        args.dwell_time,
-                    )
-                    results = collect_lmt_on_bdfs(
-                        args=args,
-                        hostname=host.hostname,
-                        host_id=host.host_id,
-                        model_name=host.model_name,
-                        bdf_list=bdf_list,
-                        receiver_number=receiver_number,
-                        left_right_none=left_right_none,
-                        up_down=up_down,
-                        steps=step,
-                        voltage_or_timing=margin_type,
-                    )
+                with reporter.start_step(
+                    name=f"Rcvr:{test_info.receiver_number} Step:{step} Ann:{test_info.annotation}"
+                ):
+                    test_info.step = step
+                    results = collect_lmt_on_bdfs(test_info=test_info, bdf_list=group.bdf_list)
                     for result in results:
                         logger.info(result)
                         reporter.write(result)

--- a/src/pci_lmt/results.py
+++ b/src/pci_lmt/results.py
@@ -21,9 +21,15 @@ class LmtTestInfo:  # pylint: disable=too-many-instance-attributes,too-few-publi
 
     run_id: str = ""
     timestamp: int = -1
-    host_id: int = -1
+    host_id: str = ""
     hostname: str = ""
     model_name: str = ""
+    receiver_number: int = -1
+    margin_type: str = ""
+    left_right_none: int = -1
+    up_down: int = -1
+    step: int = -1
+    force_margin: bool = False
     dwell_time_secs: int = -1
     elapsed_time_secs: float = -1
     error_count_limit: int = -1


### PR DESCRIPTION
Prior this change, the "annotation" printed for each group was the same. With this change, the annotation is derived from the group name (see snapshot below). This also fixes few "fixme's"

```
[root@dut /tmp]# time ./pci_lmt.par -o json -c lmt.cfg.org auto |  jq -rc '[.test_info.annotation, .device_info.bdf, .lane, .step, .error_count]' | grep -v ",0]"
["CPU Tx -> Retimer Rx (Timing left)","0000:00:01.1",0,6,63]
["CPU Tx -> Retimer Rx (Timing left)","0000:00:01.1",1,6,54]
:
["Retimer Tx -> PEX Rx (Timing left)","0000:01:00.0",3,16,1]
["Retimer Tx -> PEX Rx (Timing left)","0000:e1:00.0",7,16,1]
:
["PEX Tx -> ASIC Rx (Timing right)","0000:09:00.0",0,15,1]
["PEX Tx -> ASIC Rx (Timing right)","0000:0a:00.0",3,15,2]
```