### PR TITLE
Fixed a bug (invalid shift count) in the voltage margin logic.

### DIFF
--- a/src/pci_lmt/pcie_lane_margining.py
+++ b/src/pci_lmt/pcie_lane_margining.py
@@ -747,7 +747,7 @@ class PcieDeviceLaneMargining:
         elif margin_type == MarginType.VOLTAGE_UP:
             margin_payload = steps
         elif margin_type == MarginType.VOLTAGE_DOWN:
-            margin_payload = 1 << 6 | steps
+            margin_payload = 1 << 7 | steps
         else:
             return {"error": f"ERROR: StepMarginVoltageOffsetUpDownOfDefault - BAD margin_type {margin_type}"}
 


### PR DESCRIPTION
This bug & fix was identified by ODM when trying LMT on Yv4 with new NIC. Prior this change, the voltage-down margin reported error for all the steps. With this change, we are able to run voltage-down margining.