### PR TITLE
Returned LMT results to the caller for further post-processing.

### DIFF
--- a/src/pci_lmt/collector.py
+++ b/src/pci_lmt/collector.py
@@ -185,8 +185,14 @@ def collect_lmt_on_bdfs(test_info: LmtTestInfo, bdf_list: ty.List[str]) -> ty.Li
 # FIXME: the args param should not be here, arg parsing and usage should be limited to main.py
 # instead, replace this with the actual inputs needed; if it's too many, a RuntimeConfig can be made
 # pylint: disable=too-many-locals
-def run_lmt(args: argparse.Namespace, config: PlatformConfig, host: HostInfo, reporter: Reporter) -> None:
+def run_lmt(
+    args: argparse.Namespace, config: PlatformConfig, host: HostInfo, reporter: Reporter
+) -> ty.List[LmtLaneResult]:
     """Runs LMT tests on all the interfaces listed in the platform_config."""
+
+    # Caller may do more post-processing on the results.
+    # So, gather all results (from individual steps x BDFs x lanes) and return to the caller.
+    all_results = []
 
     logger.info("Loading config: %s", config)
     with reporter.start_run(host):
@@ -216,3 +222,7 @@ def run_lmt(args: argparse.Namespace, config: PlatformConfig, host: HostInfo, re
                     for result in results:
                         logger.info(result)
                         reporter.write(result)
+
+                    all_results.extend(results)
+
+    return all_results


### PR DESCRIPTION
This is required to log the results in more than 1 format (JSON and Internal DB in this case).