### PR TITLE
Exposed the LMT config as part of test_info.

### DIFF
--- a/src/pci_lmt/collector.py
+++ b/src/pci_lmt/collector.py
@@ -206,6 +206,7 @@ def run_lmt(
         test_info.error_count_limit = args.error_count_limit
         test_info.force_margin = args.force_margin
         test_info.test_version = PCI_LMT_VERSION
+        test_info.config = str(config)
 
         for group in config.lmt_groups:
             test_info.margin_type = group.margin_type

--- a/src/pci_lmt/results.py
+++ b/src/pci_lmt/results.py
@@ -34,6 +34,7 @@ class LmtTestInfo:  # pylint: disable=too-many-instance-attributes,too-few-publi
     error_count_limit: int = -1
     test_version: str = ""
     annotation: str = ""
+    config: str = ""
 
 
 @dc.dataclass


### PR DESCRIPTION
This is required to have the LMT config stored alongside the results