### PR TITLE
Fixed the keyword arg parsing in write_margining_lane_control_register

### DIFF
--- a/src/pci_lmt/pcie_lane_margining.py
+++ b/src/pci_lmt/pcie_lane_margining.py
@@ -111,8 +111,8 @@ class PcieDeviceLaneMargining:
     @handle_lane_status
     def write_margining_lane_control_register(
         self,
-        *,
         lane: int = 0,
+        *,
         receiver_number: int = 0x0,
         # FIXME: these magical constants should really be either named or better enums
         margin_type: int = 0x7,


### PR DESCRIPTION
This was causing: TypeError: PcieDeviceLaneMargining.write_margining_lane_control_register() takes 1 positional argument but 2 positional arguments (and 4 keyword-only arguments) were given

This bug was introduced recently in https://github.com/opencomputeproject/ocp-diag-pci_lmt/commit/c10b3984fc5f72bca74996fb0d82f7c69c714131